### PR TITLE
Fixed reconnect bug. system should recover from lost internet

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,9 @@ use crate::submission::{NockPoolSubmissionProvider, NockPoolSubmissionResponseHa
 use crate::config::Config;
 
 use clap::Parser;
-use tokio::sync::watch;
+use tokio::sync::{watch, mpsc};
 use tracing::{error, info};
-use std::sync::Arc;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 use quiver::types::{Template, Submission, Target};
 use bytes::Bytes;
 
@@ -51,6 +51,32 @@ async fn main() {
         device_info.ram_capacity_gb
     );
 
+    // --- Set up panic hook for quiver client ---
+    let (panic_tx, mut panic_rx) = mpsc::unbounded_channel::<()>();
+    let client_should_restart = Arc::new(AtomicBool::new(false));
+    let client_should_restart_hook = client_should_restart.clone();
+    
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let payload = panic_info.payload().downcast_ref::<&str>()
+            .unwrap_or(&"Unknown panic");
+        
+        // Check if this is a quiver-related panic
+        if payload.contains("failed to open submission stream") || 
+           payload.contains("TimedOut") ||
+           panic_info.location().map_or(false, |l| l.file().contains("quiver")) {
+            error!("Quiver client panic detected: {}", payload);
+            client_should_restart_hook.store(true, Ordering::SeqCst);
+            let _ = panic_tx.send(());
+        }
+        
+        // Print the panic info (preserving normal panic behavior)
+        eprintln!("thread '{}' panicked at {}:",
+                 std::thread::current().name().unwrap_or("<unnamed>"),
+                 panic_info.location().map_or("unknown location".to_string(), |l| format!("{}:{}", l.file(), l.line()))
+        );
+        eprintln!("{}", payload);
+    }));
+
     // --- Run the quiver client ---
     let Some(key) = config.key.clone() else {
         tracing::error!("No key provided");
@@ -59,31 +85,75 @@ async fn main() {
     let server_address = config.server_address.clone();
     let client_address = config.client_address.clone();
     let insecure = config.insecure.clone();
+    
     tokio::spawn(async move {
         let mut backoff_ms = 100_u64;
         let max_backoff_ms = 30_000_u64;
     
         loop {
-            if let Err(e) = quiver::client::run(
-                insecure,
-                server_address.clone(),
-                client_address.clone(),
-                key.clone(),
-                device_info.clone(),
-                new_job_consumer.clone(),
-                submission_provider.clone(),
-                submission_response_handler.clone()).await {
-                error!("Error running client: {}", e);
+            client_should_restart.store(false, Ordering::SeqCst);
+            
+            // Start the quiver client
+            let mut client_handle = tokio::spawn({
+                let server_address = server_address.clone();
+                let client_address = client_address.clone();
+                let key = key.clone();
+                let device_info = device_info.clone();
+                let new_job_consumer = new_job_consumer.clone();
+                let submission_provider = submission_provider.clone();
+                let submission_response_handler = submission_response_handler.clone();
+                
+                async move {
+                    quiver::client::run(
+                        insecure,
+                        server_address,
+                        client_address,
+                        key,
+                        device_info,
+                        new_job_consumer,
+                        submission_provider,
+                        submission_response_handler
+                    ).await
+                }
+            });
 
-                // sleep for the current backoff
-                info!("Sleeping for {}ms", backoff_ms);
-                tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
-    
-                // double, but don’t exceed max
-                backoff_ms = (backoff_ms * 2).min(max_backoff_ms);
-            } else {
-                // success: reset backoff and immediately retry (or break/return if done)
-                backoff_ms = 100;
+            // Wait for either the client to finish or a panic to occur
+            let client_result = tokio::select! {
+                result = &mut client_handle => {
+                    Some(result)
+                }
+                _ = panic_rx.recv() => {
+                    error!("Panic detected in quiver client - triggering reconnection");
+                    client_handle.abort();
+                    None
+                }
+            };
+
+            match client_result {
+                Some(Ok(Ok(()))) => {
+                    info!("Client connection completed successfully, reconnecting immediately");
+                    backoff_ms = 100;
+                }
+                Some(Ok(Err(e))) => {
+                    error!("Client connection failed: {}", e);
+                    
+                    info!("Sleeping for {}ms before reconnecting", backoff_ms);
+                    tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = (backoff_ms * 2).min(max_backoff_ms);
+                }
+                Some(Err(e)) => {
+                    error!("Client task failed: {}", e);
+                    
+                    info!("Sleeping for {}ms before reconnecting after task failure", backoff_ms);
+                    tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = (backoff_ms * 2).min(max_backoff_ms);
+                }
+                None => {
+                    // Panic was detected
+                    info!("Sleeping for {}ms before reconnecting after panic", backoff_ms);
+                    tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = (backoff_ms * 2).min(max_backoff_ms);
+                }
             }
         }
     });


### PR DESCRIPTION
  Summary of Changes

  Problem: The quiver library panics with "failed to open submission stream: TimedOut" instead of
  returning errors, which crashes the entire connection task and prevents your existing
  reconnection logic from working.

  Solution: Added a global panic hook that intercepts quiver panics and converts them into
  reconnection triggers.

  Changes Made:

  1. Added imports (main.rs:13,15):
    - tokio::sync::mpsc for panic communication channel
    - Kept existing std::sync::Arc import
  2. Added panic hook setup (main.rs:54-75):
    - Creates communication channel between panic hook and reconnection logic
    - Sets global panic hook to detect quiver-specific panics
    - Looks for "failed to open submission stream", "TimedOut", or file paths containing "quiver"
    - Sends signal to trigger reconnection when quiver panic detected
    - Preserves normal panic printing behavior
  3. Enhanced reconnection logic (main.rs:85-154):
    - Uses tokio::select! to wait for either normal client completion OR panic signal
    - When panic detected, aborts current client task and triggers reconnection with backoff
    - Preserves all existing error handling for normal client failures
    - Uses same exponential backoff (100ms to 30s)

  Key Benefits:

  - No more crashes: Panics are caught and converted to graceful reconnections
  - Same retry logic: Uses your existing exponential backoff approach
  - Better logging: Clearly distinguishes between normal errors and panic-triggered reconnections
  - Minimal changes: Preserves all existing functionality, just adds panic recovery
