### PR TITLE
Proof rate telemetry

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,5 +1,6 @@
 use sysinfo::System;
 use quiver::device_info::DeviceInfo;
+use crate::miner::get_current_proof_rate;
 
 pub fn get_device_info() -> DeviceInfo {
     let mut sys = System::new();
@@ -15,4 +16,10 @@ pub fn get_device_info() -> DeviceInfo {
         cpu_model: cpu_model.clone().trim().to_string(),
         ram_capacity_gb,
     }
+}
+
+pub fn get_device_info_with_proof_rate() -> (DeviceInfo, f64) {
+    let device_info = get_device_info();
+    let proof_rate = get_current_proof_rate();
+    (device_info, proof_rate)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod submission;
 mod auth;
 mod key_storage;
 mod key_manager;
+mod telemetry;
 
 use crate::new_job::NockPoolNewJobConsumer;
 use crate::submission::{NockPoolSubmissionProvider, NockPoolSubmissionResponseHandler};
@@ -110,6 +111,18 @@ async fn main() {
     let server_address = config.server_address.clone();
     let client_address = config.client_address.clone();
     let insecure = config.insecure.clone();
+    
+    // --- Start telemetry client ---
+    let telemetry_client = telemetry::TelemetryClient::new(
+        key.clone(), 
+        config.api_url.clone()
+    );
+    
+    tokio::spawn(async move {
+        if let Err(e) = telemetry_client.start_telemetry_loop().await {
+            tracing::error!("Telemetry client failed: {}", e);
+        }
+    });
     
     // 24-hour restart timer
     tokio::spawn(async move {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use reqwest::Client;
+use serde::Serialize;
+use std::time::Duration;
+use tokio::time::{interval, sleep};
+use tracing::{error, info, warn};
+
+use crate::device::get_device_info_with_proof_rate;
+
+#[derive(Debug, Serialize)]
+struct TelemetryData {
+    device_os: String,
+    device_cpu: String,
+    device_ram_capacity_gb: u64,
+    device_proof_rate_per_sec: f64,
+}
+
+pub struct TelemetryClient {
+    client: Client,
+    api_key: String,
+    api_base_url: String,
+}
+
+impl TelemetryClient {
+    pub fn new(api_key: String, api_base_url: String) -> Self {
+        Self {
+            client: Client::new(),
+            api_key,
+            api_base_url,
+        }
+    }
+
+    pub async fn send_telemetry(&self) -> Result<()> {
+        let (device_info, proof_rate) = get_device_info_with_proof_rate();
+        
+        let telemetry = TelemetryData {
+            device_os: device_info.os,
+            device_cpu: device_info.cpu_model,
+            device_ram_capacity_gb: device_info.ram_capacity_gb,
+            device_proof_rate_per_sec: proof_rate,
+        };
+
+        let api_url = format!("{}/api/v1/telemetry", self.api_base_url);
+        
+        let response = self
+            .client
+            .post(&api_url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&telemetry)
+            .timeout(Duration::from_secs(30))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            info!("Telemetry sent successfully: {:.4} proofs/sec", proof_rate);
+        } else {
+            let status = response.status();
+            let error_text = response.text().await?;
+            warn!("Failed to send telemetry ({}): {}", status, error_text);
+        }
+
+        Ok(())
+    }
+
+    pub async fn start_telemetry_loop(&self) -> Result<()> {
+        let mut interval = interval(Duration::from_secs(300)); // Send telemetry every 5 minutes
+        
+        loop {
+            interval.tick().await;
+            
+            if let Err(e) = self.send_telemetry().await {
+                error!("Error sending telemetry: {}", e);
+                // Don't break the loop on error, just wait and try again
+                sleep(Duration::from_secs(10)).await;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a way for the miner to measure its proof rate. it then sends the data to the backend every 5 minutes.